### PR TITLE
Allow the usage of '##' within the documentation

### DIFF
--- a/doxygen-bash.sed
+++ b/doxygen-bash.sed
@@ -46,6 +46,7 @@
     # list of parameters in the funcname(<here>).
     s/\(@fn \([^(]\+\)(\)\([^)]*\)\().*\)\n\2() *{/\1\3\4\n\2(\3) { }/
     # Replace all '## ' by '//! ' at beginning-of-line.
+    s/\(^\|\n\)##\n/\1\/\/!\n/g
     s/\(^\|\n\)## /\1\/\/! /g
     p
     b end
@@ -153,7 +154,7 @@
 
 # Delete non doxygen-related lines content, but not the line
 # themselves.
-/^## /!{
+/^## \|^##$/!{
      s/^.*$//p
 }
 b end
@@ -165,4 +166,4 @@ b declareprint
 
 :end
 # Make all ## lines doxygen-able.
-s/^## /\/\/! /p
+s/^##\( \|$\)/\/\/!\1/p

--- a/test/input
+++ b/test/input
@@ -6,6 +6,7 @@
 ## @brief Bash Doxgen Unit Test
 ## @copyright WTFPLv2
 ## @version 1
+##
 
 declare -r readonly
 declare -r assigned_readonly=readonly-value
@@ -39,6 +40,8 @@ export assigned_exported=1
 ## @fn function_1()
 ## @brief 1st function
 ## @param param1 first parameter
+##
+## Don't skip empty line above
 function_1() {
 	bogus
 	bogus2;

--- a/test/output
+++ b/test/output
@@ -6,6 +6,7 @@
 //! @brief Bash Doxgen Unit Test
 //! @copyright WTFPLv2
 //! @version 1
+//!
 
 ReadOnly String readonly;
 ReadOnly String assigned_readonly = readonly-value;
@@ -39,6 +40,8 @@ Exported String assigned_exported = 1;
 //! @fn function_1(param1)
 //! @brief 1st function
 //! @param param1 first parameter
+//!
+//! Don't skip empty line above
 function_1(param1) { }
 
 


### PR DESCRIPTION
Allow the usage of '##' to signal a doxygen part and don't consits on the '## '
